### PR TITLE
英語対応した #5

### DIFF
--- a/src/components/profile.tsx
+++ b/src/components/profile.tsx
@@ -1,9 +1,11 @@
 import Image from 'next/image'
+import { useRouter } from 'next/router'
 import BuyMeACoffeeWidget from '../components/coffee'
 import OtherSites from '../components/otherSites'
 import styles from '../styles/home/profile.module.css'
 
 export default function Profile() {
+  const { locale } = useRouter()
   return (
     <div className={styles.profile}>
       <div className={styles.left}>
@@ -14,8 +16,8 @@ export default function Profile() {
         <BuyMeACoffeeWidget />
       </div>
       <div className={styles.right}>
-        <div className={styles.name}>蔀</div>
-        （しとみ）
+        <div className={styles.name}>{locale === 'ja' ? '蔀' : 'Shetommy'}</div>
+        {locale === 'ja' ? '（しとみ）' : ''}
         <ul>
           <li>iOSエンジニア</li>
           <li>楽天イーグルスファン</li>


### PR DESCRIPTION
ブラウザの設定を日本語以外にしてる場合に、アカウント名を蔀（しとみ）からShetommyに。
（機械翻訳だとShitomi表記になってしまうため、ここだけは手で対応する必要があった）

![image](https://user-images.githubusercontent.com/45909001/138580255-d79ba622-16a4-40c5-a9d6-36cc07e8eb0d.png)

その他のページについては、ブラウザの機械翻訳を利用して読んでもらう方針