### PR TITLE
Fix iPad layout display issues

### DIFF
--- a/src/styles/header.module.css
+++ b/src/styles/header.module.css
@@ -26,6 +26,12 @@
   font-weight: 600;
 }
 
+@media (max-width: 1024px) and (min-width: 768px) {
+  .header {
+    padding: 1.5em 0;
+  }
+}
+
 @media (max-width: 600px) {
   .header {
     padding: 0.5em 0 2em;

--- a/src/styles/home/home.module.css
+++ b/src/styles/home/home.module.css
@@ -29,6 +29,19 @@
   font-size: 0.9rem;
 }
 
+@media (max-width: 1024px) and (min-width: 768px) {
+  .cardsRow {
+    max-width: 50rem;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+  
+  .contents {
+    margin: 1.5rem;
+    padding: 1.5rem;
+  }
+}
+
 @media (max-width: 900px) {
   .cardsRow {
     max-width: 35rem;

--- a/src/styles/home/profile.module.css
+++ b/src/styles/home/profile.module.css
@@ -26,6 +26,16 @@
   font-size: 3rem;
 }
 
+@media (max-width: 1024px) and (min-width: 768px) {
+  .right {
+    max-width: 24rem;
+  }
+  
+  .name {
+    font-size: 2.5rem;
+  }
+}
+
 @media (max-width: 900px) {
   .right {
     max-width: 16rem;

--- a/src/styles/home/works.module.css
+++ b/src/styles/home/works.module.css
@@ -27,3 +27,14 @@
   font-size: 0.9rem;
   max-width: 10rem;
 }
+
+@media (max-width: 1024px) and (min-width: 768px) {
+  .work {
+    margin: 1.5rem;
+    padding: 1.5rem;
+  }
+  
+  .content .description {
+    max-width: 12rem;
+  }
+}


### PR DESCRIPTION
- Add iPad-specific breakpoints (768px-1024px) for optimized layout
- Increase cardsRow max-width to 50rem on iPad for better content visibility
- Improve touch scrolling with -webkit-overflow-scrolling: touch
- Expand profile section max-width to 24rem on iPad
- Adjust name font size for better iPad display
- Optimize work card spacing and description width
- Add iPad-specific header padding

Fixes #64

🤖 Generated with [Claude Code](https://claude.ai/code)