### PR TITLE
Add time-based automatic theme switching

### DIFF
--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { useTheme } from '../context/ThemeContext';
+import styles from '../styles/ThemeToggle.module.css';
+
+const ThemeToggle: React.FC = () => {
+  const { theme, toggleTheme } = useTheme();
+  
+  return (
+    <button 
+      className={styles.themeToggle} 
+      onClick={toggleTheme}
+      aria-label={`Switch to ${theme === 'light' ? 'dark' : 'light'} mode`}
+    >
+      {theme === 'light' ? '🌙' : '☀️'}
+    </button>
+  );
+};
+
+export default ThemeToggle;

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -2,6 +2,7 @@ import Link from 'next/link'
 import Head from 'next/head'
 import { useRouter } from 'next/router'
 import styles from '../styles/header.module.css'
+import ThemeToggle from './ThemeToggle'
 
 const navItems: { label: string; page?: string; link?: string }[] = [
   { label: 'Home', page: '/' },
@@ -57,6 +58,9 @@ const Header = ({ titlePre = '' }) => {
           </li>
         ))}
       </ul>
+      <div className={styles.themeToggleContainer}>
+        <ThemeToggle />
+      </div>
     </header>
   )
 }

--- a/src/context/ThemeContext.tsx
+++ b/src/context/ThemeContext.tsx
@@ -1,0 +1,52 @@
+import React, { createContext, useContext, useState, useEffect } from 'react';
+
+type Theme = 'light' | 'dark';
+
+interface ThemeContextType {
+  theme: Theme;
+  toggleTheme: () => void;
+}
+
+const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
+
+export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [theme, setTheme] = useState<Theme>('light');
+
+  // Initialize theme from localStorage or system preference
+  useEffect(() => {
+    const savedTheme = localStorage.getItem('theme') as Theme;
+    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    
+    if (savedTheme) {
+      setTheme(savedTheme);
+    } else if (prefersDark) {
+      setTheme('dark');
+    }
+  }, []);
+
+  // Update document with theme class when theme changes
+  useEffect(() => {
+    const root = window.document.documentElement;
+    root.classList.remove('light-theme', 'dark-theme');
+    root.classList.add(`${theme}-theme`);
+    localStorage.setItem('theme', theme);
+  }, [theme]);
+
+  const toggleTheme = () => {
+    setTheme(prevTheme => (prevTheme === 'light' ? 'dark' : 'light'));
+  };
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+};
+
+export const useTheme = (): ThemeContextType => {
+  const context = useContext(ThemeContext);
+  if (context === undefined) {
+    throw new Error('useTheme must be used within a ThemeProvider');
+  }
+  return context;
+};

--- a/src/context/ThemeContext.tsx
+++ b/src/context/ThemeContext.tsx
@@ -9,18 +9,44 @@ interface ThemeContextType {
 
 const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
 
+const isNightTime = (): boolean => {
+  const hour = new Date().getHours();
+  return hour >= 19 || hour < 7; // 7PM to 7AM is considered night time
+};
+
 export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const [theme, setTheme] = useState<Theme>('light');
 
-  // Initialize theme from localStorage or system preference
+  // Initialize theme from localStorage, system preference, or time of day
   useEffect(() => {
     const savedTheme = localStorage.getItem('theme') as Theme;
     const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    const autoTheme = localStorage.getItem('autoTheme');
     
-    if (savedTheme) {
+    if (savedTheme && autoTheme !== 'true') {
+      // User has manually set a theme and auto mode is off
       setTheme(savedTheme);
+    } else if (autoTheme === 'true' || (!savedTheme && !prefersDark)) {
+      // Auto mode is on, or no preference saved - use time-based theme
+      const timeBasedTheme = isNightTime() ? 'dark' : 'light';
+      setTheme(timeBasedTheme);
+      localStorage.setItem('autoTheme', 'true');
     } else if (prefersDark) {
+      // Fall back to system preference
       setTheme('dark');
+    }
+  }, []);
+
+  // Set up interval to check time every minute for auto theme switching
+  useEffect(() => {
+    const autoTheme = localStorage.getItem('autoTheme');
+    if (autoTheme === 'true') {
+      const interval = setInterval(() => {
+        const timeBasedTheme = isNightTime() ? 'dark' : 'light';
+        setTheme(timeBasedTheme);
+      }, 60000); // Check every minute
+
+      return () => clearInterval(interval);
     }
   }, []);
 
@@ -33,6 +59,8 @@ export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ childre
   }, [theme]);
 
   const toggleTheme = () => {
+    // When user manually toggles, disable auto mode
+    localStorage.setItem('autoTheme', 'false');
     setTheme(prevTheme => (prevTheme === 'light' ? 'dark' : 'light'));
   };
 

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -2,15 +2,16 @@ import '../styles/globals.css'
 import usePageView from '../components/hooks/usePageView'
 import GoogleAnalytics from '../components/googleAnalytics'
 import type { AppProps } from 'next/app'
+import { ThemeProvider } from '../context/ThemeContext'
 
 function MyApp({ Component, pageProps }: AppProps) {
   usePageView()
 
   return (
-    <>
+    <ThemeProvider>
       <GoogleAnalytics />
       <Component {...pageProps} />
-    </>
+    </ThemeProvider>
   )
 }
 export default MyApp

--- a/src/styles/ThemeToggle.module.css
+++ b/src/styles/ThemeToggle.module.css
@@ -1,0 +1,29 @@
+.themeToggle {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 1.5rem;
+  padding: 0.5rem;
+  margin-left: 1rem;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  transition: background-color 0.3s ease;
+  background-color: var(--accents-1);
+}
+
+.themeToggle:hover {
+  background-color: var(--accents-2);
+}
+
+@media (max-width: 600px) {
+  .themeToggle {
+    font-size: 1.2rem;
+    width: 2rem;
+    height: 2rem;
+    margin-left: 0.5rem;
+  }
+}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,14 +1,55 @@
+:root {
+  /* Light theme variables */
+  --background-color: #ffffff;
+  --text-color: #000000;
+  --accent-color: #0070f3;
+  --secondary-color: #666666;
+  --border-color: #eaeaea;
+  --card-background: #f9f9f9;
+  --accents-1: #fafafa;
+  --accents-2: #eaeaea;
+  --accents-3: #999999;
+}
+
+.light-theme {
+  --background-color: #ffffff;
+  --text-color: #000000;
+  --accent-color: #0070f3;
+  --secondary-color: #666666;
+  --border-color: #eaeaea;
+  --card-background: #f9f9f9;
+  --accents-1: #fafafa;
+  --accents-2: #eaeaea;
+  --accents-3: #999999;
+}
+
+.dark-theme {
+  --background-color: #121212;
+  --text-color: #e0e0e0;
+  --accent-color: #0070f3;
+  --secondary-color: #a0a0a0;
+  --border-color: #333333;
+  --card-background: #1e1e1e;
+  --accents-1: #111111;
+  --accents-2: #333333;
+  --accents-3: #666666;
+}
+
 html,
 body {
   padding: 0;
   margin: 0;
   font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen,
     Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue, sans-serif;
+  background-color: var(--background-color);
+  color: var(--text-color);
+  transition: background-color 0.3s ease, color 0.3s ease;
 }
 
 a {
-  color: inherit;
+  color: var(--accent-color);
   text-decoration: none;
+  transition: color 0.3s ease;
 }
 
 a:hover,

--- a/src/styles/header.module.css
+++ b/src/styles/header.module.css
@@ -1,9 +1,12 @@
 .header {
-  display: block;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
   min-height: 64px;
   padding: 2em 0;
   text-align: center;
   letter-spacing: -0.02em;
+  position: relative;
 }
 
 .header ul {
@@ -22,12 +25,23 @@
 }
 
 .header :global(p.active) {
-  color: #0070f3;
+  color: var(--accent-color);
   font-weight: 600;
+}
+
+.themeToggleContainer {
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
 }
 
 @media (max-width: 600px) {
   .header {
     padding: 0.5em 0 2em;
+  }
+  
+  .themeToggleContainer {
+    top: 0.5rem;
+    right: 0.5rem;
   }
 }

--- a/src/styles/home/other_sites.module.css
+++ b/src/styles/home/other_sites.module.css
@@ -6,6 +6,16 @@
   filter: brightness(0);
 }
 
+/* ライトモードではSVGを暗く */
+:global([data-theme="light"]) .links {
+  filter: brightness(0);
+}
+
+/* ダークモードではSVGを明るく */
+:global([data-theme="dark"]) .links {
+  filter: brightness(10);
+}
+
 .links a {
   width: 48px;
   height: 48px;


### PR DESCRIPTION
## Summary
• Add automatic dark mode switching based on time of day (7PM-7AM)
• Disable auto mode when user manually toggles theme
• Check time every minute for automatic switching

## Test plan
- [ ] Verify manual theme toggle still works correctly
- [ ] Test automatic switching during day/night transition times
- [ ] Confirm auto mode disables when manually toggled
- [ ] Check that theme preferences are properly saved to localStorage

🤖 Generated with [Claude Code](https://claude.ai/code)