### PR TITLE
Add date display to article pages

### DIFF
--- a/src/pages/articles/[title].tsx
+++ b/src/pages/articles/[title].tsx
@@ -4,6 +4,7 @@ import {
   getPageTitle,
   getBlocks,
   isPublishDate,
+  getPageDate,
   type NotionPage,
   ExtendNotionBlock
 } from '../../components/notion'
@@ -18,12 +19,15 @@ import { Fragment } from 'react'
 import { InferGetStaticPropsType, GetStaticPropsContext } from 'next'
 import { ParsedUrlQuery } from 'querystring'
 
-export default function Post({ title, blocks, tableOfContentsBlocks }: Props) {
+export default function Post({ title, blocks, tableOfContentsBlocks, publishDate }: Props) {
   return (
     <div>
       <Header titlePre={title} />
       <article className={styles.container}>
         <h1 className={styles.name}>{title}</h1>
+        <time className={styles.date} dateTime={publishDate}>
+          {new Date(publishDate).toLocaleDateString()}
+        </time>
         <section>
           {blocks.map((block) => (
             <Fragment key={block.id}>{renderBlock({ block: block, tableOfContents: tableOfContentsBlocks })}</Fragment>
@@ -71,6 +75,8 @@ export const getStaticProps = async (context: GetStaticPropsContext) => {
   const blocks = await getBlocks(id)
   saveImageIfNeeded(blocks)
 
+  const publishDate = getPageDate(page as NotionPage).toISOString()
+
   const blocksWithOGP: ExtendNotionBlock[] = []
   const tableOfContentsBlocks: ExtendNotionBlock[] = []
   
@@ -104,6 +110,7 @@ export const getStaticProps = async (context: GetStaticPropsContext) => {
       title,
       blocks: blocksWithOGP,
       tableOfContentsBlocks: tableOfContentsBlocks,
+      publishDate,
     },
     revalidate: 1,
   }

--- a/src/styles/articles/post.module.css
+++ b/src/styles/articles/post.module.css
@@ -8,6 +8,14 @@
 
 .container .name {
   font-size: 32px;
+  margin-bottom: 8px;
+}
+
+.container .date {
+  display: block;
+  color: #666;
+  font-size: 14px;
+  margin-bottom: 24px;
 }
 
 .container h1 {


### PR DESCRIPTION
## Summary
- Add date display functionality to article pages below the title
- Use existing `getPageDate` function to retrieve publish date from Notion
- Display date in browser's locale format for international compatibility
- Include semantic HTML with proper `time` element and `dateTime` attribute

## Changes
- Import `getPageDate` from notion components
- Add date display in article template with proper styling
- Use ISO format for `dateTime` attribute and locale format for display
- Style date with appropriate color and spacing

## Test plan
- [x] Verify date appears below article title
- [x] Confirm date format matches browser locale settings
- [x] Check semantic HTML structure with time element
- [x] Validate styling and spacing

Close #85

🤖 Generated with [Claude Code](https://claude.ai/code)