### PR TITLE
docs: タスク開始時のworktree/ブランチ/コミット/pushルールを強制

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,4 +74,8 @@ When working with blog functionality:
 
 ## Global Rule
 
-- [MANDATORY] Answer in Japanese 
+- [MANDATORY] Answer in Japanese
+- [MANDATORY] タスクに取り掛かる前に、必ず新しいgit worktreeを作成し、その中で作業すること。worktreeのブランチ名はタスクの内容を表す名前にすること（例: `git worktree add ../shetommy-<branch-name> -b <branch-name>`）
+- [MANDATORY] worktree内で作業ブランチを新規作成すること（mainブランチに直接コミットしない）
+- [MANDATORY] コミットは適切な単位で行うこと。1つのコミットに複数の無関係な変更を混在させない。機能追加・バグ修正・リファクタリングはそれぞれ別コミットにする
+- [MANDATORY] 修正が完了したら必ず `git push` でリモートにpushすること


### PR DESCRIPTION
## Summary
- CLAUDE.mdのGlobal Ruleにタスク開始時のワークフロールールを追加
- git worktreeの新規作成、作業ブランチの作成、適切なコミット粒度、完了後のpushを必須化

## 追加したルール
- タスク開始前に新しいgit worktreeを作成する
- worktree内で作業ブランチを新規作成する（mainへの直接コミット禁止）
- コミットは適切な単位で行う（機能・バグ修正・リファクタリングを分離）
- 修正完了後は必ずgit pushする

🤖 Generated with [Claude Code](https://claude.com/claude-code)