### PR TITLE
chore: ignore next-env.d.ts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 # next.js
 /.next/
 /out/
+next-env.d.ts
 
 # production
 /build

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,5 +1,0 @@
-/// <reference types="next" />
-/// <reference types="next/image-types/global" />
-
-// NOTE: This file should not be edited
-// see https://nextjs.org/docs/basic-features/typescript for more information.


### PR DESCRIPTION
## Summary

- Closes #115
- `next-env.d.ts` を `.gitignore` に追加し、gitの追跡から除外
- Next.js公式ドキュメントに従った対応: https://nextjs.org/docs/app/api-reference/config/typescript#next-envdts

> This file is auto-generated by Next.js and should not be edited or removed. This file should not be committed to source control.

🤖 Generated with [Claude Code](https://claude.com/claude-code)