### PR TITLE
feat: Notionの表ブロックに対応する

### DIFF
--- a/src/components/utils/renderNotionBlock.tsx
+++ b/src/components/utils/renderNotionBlock.tsx
@@ -231,6 +231,8 @@ export const renderBlock = (
       const url = pdfValue.type === 'external' ? pdfValue.external.url : pdfValue.file.url
       return <iframe src={url} width="100%" height="600px" />
     }
+    case 'table':
+      return <TableComponent block={block} />
     default:
       return `❌ Unsupported block (${
         type === 'unsupported' ? 'unsupported by Notion API' : type
@@ -330,6 +332,47 @@ const renderNumberedListItem = (block: ExtendNotionBlock) => {
         <NumberedListItem key={block.id} block={block} />
       )}
     </ol>
+  )
+}
+
+const TableComponent: React.FC<{ block: ExtendNotionBlock }> = ({ block }) => {
+  if (block.type !== 'table') return null
+
+  const { has_column_header, has_row_header } = block.table
+  const rows = block.children ?? []
+  const headerRow = has_column_header ? rows[0] : null
+  const bodyRows = has_column_header ? rows.slice(1) : rows
+
+  const renderCell = (cell: RichText[], isHeader: boolean, scope?: 'col' | 'row', key?: number) => {
+    const Tag = isHeader ? 'th' : 'td'
+    return (
+      <Tag key={key} className={isHeader ? styles.tableHeader : styles.tableCell} scope={scope}>
+        <TextComponent richTexts={cell} />
+      </Tag>
+    )
+  }
+
+  const renderRow = (rowBlock: ExtendNotionBlock, isHeaderRow: boolean) => {
+    if (rowBlock.type !== 'table_row') return null
+    const cells = rowBlock.table_row.cells as RichText[][]
+    return (
+      <tr key={rowBlock.id}>
+        {cells.map((cell, colIndex) => {
+          if (isHeaderRow) return renderCell(cell, true, 'col', colIndex)
+          if (has_row_header && colIndex === 0) return renderCell(cell, true, 'row', colIndex)
+          return renderCell(cell, false, undefined, colIndex)
+        })}
+      </tr>
+    )
+  }
+
+  return (
+    <div className={styles.tableWrapper}>
+      <table className={styles.table}>
+        {headerRow && <thead>{renderRow(headerRow, true)}</thead>}
+        <tbody>{bodyRows.map((row) => renderRow(row, false))}</tbody>
+      </table>
+    </div>
   )
 }
 

--- a/src/styles/articles/post.module.css
+++ b/src/styles/articles/post.module.css
@@ -190,6 +190,32 @@
   text-overflow: ellipsis;
 }
 
+.tableWrapper {
+  overflow-x: auto;
+  margin: 8px 0;
+  -webkit-overflow-scrolling: touch;
+}
+
+.table {
+  border-collapse: collapse;
+  width: 100%;
+  font-size: 14px;
+}
+
+.tableHeader,
+.tableCell {
+  border: 1px solid var(--border-color);
+  padding: 8px 12px;
+  text-align: left;
+  vertical-align: top;
+  word-break: break-word;
+}
+
+.tableHeader {
+  background-color: var(--quote-background-color);
+  font-weight: bold;
+}
+
 .container nav {
   background-color: var(--quote-background-color);
   padding: 16px;


### PR DESCRIPTION
## Summary
- `renderNotionBlock.tsx` に `TableComponent` を追加し、`case 'table'` をswitch文に追加
- `has_column_header` が true の場合、先頭行を `<thead>` でラップ
- `has_row_header` が true の場合、各行の先頭セルを `<th scope="row">` でレンダリング
- `post.module.css` にレスポンシブ対応のテーブルスタイルを追加（`--border-color` / `--quote-background-color` 変数でダーク/ライトモード自動対応）

Closes #92

## Test plan
- [x] Notionにテーブルブロックを含む記事を作成し、`npm run dev` で表示確認
- [x] 列ヘッダーあり/なし、行ヘッダーあり/なしの組み合わせを確認
- [x] セル内リッチテキスト（太字、斜体、リンク等）の表示確認
- [ ] モバイル幅でのスクロール動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)