### PR TITLE
リファクタリング: getBlocksのvar削除と番号付きリスト処理をイミュータブルに変更

### DIFF
--- a/src/components/Notion.tsx
+++ b/src/components/Notion.tsx
@@ -182,21 +182,26 @@ export const getBlocks = async (blockId: string) => {
     cursor = next_cursor
   }
   // 番号付きリストの順序性を保つためにリスト1ブロック目に全てのブロックを保持させる
-  var numberedListItems: ExtendNotionBlock[] = []
-  blocks.forEach((block, index) => {
-    if (block.type == 'numbered_list_item') {
-      numberedListItems.push(block)
-      if (blocks[index + 1]?.type != 'numbered_list_item') {
-        blocks[index - numberedListItems.length + 1] = {
-          ...blocks[index - numberedListItems.length + 1],
-          numberedListBlocks: numberedListItems
-        }
-        numberedListItems = []
+  const { result: groupedBlocks } = blocks.reduce<{
+    result: ExtendNotionBlock[]
+    group: ExtendNotionBlock[]
+  }>(
+    ({ result, group }, block, index) => {
+      if (block.type !== 'numbered_list_item') {
+        return { result: [...result, block], group: [] }
       }
-    }
-  })
+      const newGroup = [...group, block]
+      const isLastInGroup = blocks[index + 1]?.type !== 'numbered_list_item'
+      if (isLastInGroup) {
+        const head = { ...newGroup[0], numberedListBlocks: newGroup }
+        return { result: [...result, head], group: [] }
+      }
+      return { result, group: newGroup }
+    },
+    { result: [], group: [] }
+  )
 
-  return blocks
+  return groupedBlocks
 }
 
 /// ブロックに子ブロックがあれば付与する（リストブロック・トグルブロック）


### PR DESCRIPTION
## Summary
- `var` キーワードを `let` に変更（#128）
- `getBlocks` 内の番号付きリストグループ化処理を `reduce` を使ったイミュータブルな実装に置き換え（#133）
  - 配列の直接書き換え（ミューテーション）を排除
  - 複雑なインデックス計算（`index - numberedListItems.length + 1`）を除去

## Test plan
- [ ] `tsc` で型エラーがないことを確認済み
- [ ] 番号付きリストを含む記事が正しく表示されることを目視確認

Closes #128
Closes #133

🤖 Generated with [Claude Code](https://claude.com/claude-code)