### PR TITLE
feat: 外部画像にNext.js Imageコンポーネントを適用

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,13 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: '**',
+      },
+    ],
+  },
+}
+
+module.exports = nextConfig

--- a/src/components/utils/renderNotionBlock.tsx
+++ b/src/components/utils/renderNotionBlock.tsx
@@ -127,10 +127,13 @@ export const renderBlock = (
         const src = imageValue.external.url
         return (
           <figure>
-            <img
+            <Image
               src={src}
               alt={caption}
-              style={{ cursor: onImageClick ? 'zoom-in' : undefined }}
+              width={800}
+              height={600}
+              unoptimized
+              style={{ width: 'auto', height: 'auto', maxWidth: '100%', cursor: onImageClick ? 'zoom-in' : undefined }}
               onClick={onImageClick ? () => onImageClick(src, caption) : undefined}
             />
             {caption && <figcaption>{caption}</figcaption>}


### PR DESCRIPTION
closes #129

## Summary
- Notion の外部画像（`image.type === 'external'`）を `<img>` タグから Next.js `<Image>` コンポーネントに変更
- `next.config.js` を新規作成し、外部画像ドメインの `remotePatterns` を設定
- 外部画像はサイズが不明なため `unoptimized` prop を使用

## Test plan
- [ ] `npm run build` でビルドエラーがないことを確認
- [ ] 外部画像を含む記事が正常に表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)