### PR TITLE
feat: エラーハンドリングの改善 (#125)

### DIFF
--- a/src/components/Notion.tsx
+++ b/src/components/Notion.tsx
@@ -35,7 +35,9 @@ export const getDatabase = async (databaseId: string) => {
     return response.results
   } catch (error: unknown) {
     if (isNotionClientError(error)) {
-      console.log(error.message)
+      console.error('[Notion] API error in getDatabase:', error.message)
+    } else {
+      console.error('[Notion] Unexpected error in getDatabase:', error)
     }
     return []
   }
@@ -62,7 +64,9 @@ export const getDatabaseWithPagination = async (databaseId: string, startCursor?
     }
   } catch (error: unknown) {
     if (isNotionClientError(error)) {
-      console.log(error.message)
+      console.error('[Notion] API error in getDatabaseWithPagination:', error.message)
+    } else {
+      console.error('[Notion] Unexpected error in getDatabaseWithPagination:', error)
     }
     return {
       results: [],
@@ -125,28 +129,37 @@ export const getOpeningSentence = async (blockId: string) => {
   let openingSentence = ''
   let cursor: undefined | string = undefined
 
-  while (true) {
-    const block = await Notion.blocks.children.list({
-      start_cursor: cursor,
-      block_id: blockId,
-      page_size: 10,
-    })
+  try {
+    while (true) {
+      const block = await Notion.blocks.children.list({
+        start_cursor: cursor,
+        block_id: blockId,
+        page_size: 10,
+      })
 
-    for (const result of block.results) {
-      if ('type' in result && result.type === 'paragraph') {
-        result.paragraph.text.forEach((textObject) => {
-          openingSentence += textObject.plain_text
-        })
+      for (const result of block.results) {
+        if ('type' in result && result.type === 'paragraph') {
+          result.paragraph.text.forEach((textObject) => {
+            openingSentence += textObject.plain_text
+          })
+        }
+        if (openingSentence.length >= 140) break
       }
-      if (openingSentence.length >= 140) break
-    }
 
-    const next_cursor = block.next_cursor as string | null
-    if (openingSentence.length >= 140 || !next_cursor) {
-      break
+      const next_cursor = block.next_cursor as string | null
+      if (openingSentence.length >= 140 || !next_cursor) {
+        break
+      }
+      cursor = next_cursor
     }
-    cursor = next_cursor
+  } catch (error: unknown) {
+    if (isNotionClientError(error)) {
+      console.error('[Notion] API error in getOpeningSentence:', error.message)
+    } else {
+      console.error('[Notion] Unexpected error in getOpeningSentence:', error)
+    }
   }
+
   return openingSentence.substring(0, 140)
 }
 
@@ -155,32 +168,42 @@ export const getBlocks = async (blockId: string) => {
   const blocks: ExtendNotionBlock[] = []
   let cursor: undefined | string = undefined
 
-  while (true) {
-    const blocksList = await Notion.blocks.children.list({
-      start_cursor: cursor,
-      block_id: blockId,
-    })
-    const extendNotionBlock = await Promise.all(
-      blocksList.results.filter(
-        (block): block is ExtendNotionBlock => {
-          return 'type' in block
-        }
+  try {
+    while (true) {
+      const blocksList = await Notion.blocks.children.list({
+        start_cursor: cursor,
+        block_id: blockId,
+      })
+      const extendNotionBlock = await Promise.all(
+        blocksList.results.filter(
+          (block): block is ExtendNotionBlock => {
+            return 'type' in block
+          }
+        )
+        .map(
+          (block) => {
+            return appendChildren(block)
+          }
+        )
       )
-      .map(
-        (block) => {
-          return appendChildren(block)
-        }
-      )
-    )
 
-    blocks.push(...extendNotionBlock)
+      blocks.push(...extendNotionBlock)
 
-    const next_cursor = blocksList.next_cursor as string | null
-    if (!next_cursor) {
-      break
+      const next_cursor = blocksList.next_cursor as string | null
+      if (!next_cursor) {
+        break
+      }
+      cursor = next_cursor
     }
-    cursor = next_cursor
+  } catch (error: unknown) {
+    if (isNotionClientError(error)) {
+      console.error('[Notion] API error in getBlocks:', error.message)
+    } else {
+      console.error('[Notion] Unexpected error in getBlocks:', error)
+    }
+    return blocks
   }
+
   // 番号付きリストの順序性を保つためにリスト1ブロック目に全てのブロックを保持させる
   var numberedListItems: ExtendNotionBlock[] = []
   blocks.forEach((block, index) => {
@@ -202,17 +225,21 @@ export const getBlocks = async (blockId: string) => {
 /// ブロックに子ブロックがあれば付与する（リストブロック・トグルブロック）
 const appendChildren = async (block: ExtendNotionBlock): Promise<ExtendNotionBlock> => {
   if (block.has_children) {
-    const childBlocks = await getBlocks(block.id)
-    const childrenWithNestedBlocks = await Promise.all(
-      childBlocks.map(childBlock => 
-        appendChildren(childBlock)
+    try {
+      const childBlocks = await getBlocks(block.id)
+      const childrenWithNestedBlocks = await Promise.all(
+        childBlocks.map(childBlock =>
+          appendChildren(childBlock)
+        )
       )
-    )
-    
-    return {
-      ...block,
-      children: childrenWithNestedBlocks
+
+      return {
+        ...block,
+        children: childrenWithNestedBlocks
+      }
+    } catch (error: unknown) {
+      console.error('[Notion] Error in appendChildren for block:', block.id, error)
     }
   }
-  return block 
+  return block
 }

--- a/src/components/utils/getOgpData.tsx
+++ b/src/components/utils/getOgpData.tsx
@@ -2,18 +2,27 @@ import openGraphScraper from 'open-graph-scraper'
 import { type OgObject } from 'open-graph-scraper/dist/lib/types.d'
 
 const getOgpData = async (url: string): Promise<OgObject> => {
-  const options = { url }
+  if (!url) {
+    return {} as OgObject
+  }
+
+  const options = { url, timeout: 10000 }
 
   try {
     const { result } = await openGraphScraper(options)
 
     if (!result.success) {
-      throw new Error('Failed to fetch OGP data')
+      console.error('[OGP] Failed to fetch OGP data for URL:', url)
+      return {} as OgObject
     }
 
     return result
   } catch (error) {
-    console.error('Error fetching OGP data:', error)
+    if (error instanceof Error) {
+      console.error('[OGP] Error fetching OGP data for URL:', url, error.message)
+    } else {
+      console.error('[OGP] Unknown error fetching OGP data for URL:', url)
+    }
     return {} as OgObject
   }
 }

--- a/src/pages/articles/index.tsx
+++ b/src/pages/articles/index.tsx
@@ -77,15 +77,20 @@ export default function Home({ initialArticles, hasMore: initialHasMore, nextCur
   const [hasMore, setHasMore] = useState(initialHasMore)
   const [nextCursor, setNextCursor] = useState(initialNextCursor)
   const [loading, setLoading] = useState(false)
+  const [loadError, setLoadError] = useState<string | null>(null)
 
   const loadMoreArticles = async () => {
     if (loading || !hasMore) return
-    
+
     setLoading(true)
+    setLoadError(null)
     try {
       const response = await fetch(`/api/articles/more?cursor=${nextCursor || ''}`)
+      if (!response.ok) {
+        throw new Error(`サーバーエラー: ${response.status}`)
+      }
       const data = await response.json()
-      
+
       if (data.articles) {
         setArticles(prev => [...prev, ...data.articles])
         setHasMore(data.hasMore)
@@ -93,6 +98,7 @@ export default function Home({ initialArticles, hasMore: initialHasMore, nextCur
       }
     } catch (error) {
       console.error('Error loading more articles:', error)
+      setLoadError('記事の読み込みに失敗しました。しばらくしてから再試行してください。')
     } finally {
       setLoading(false)
     }
@@ -129,9 +135,12 @@ export default function Home({ initialArticles, hasMore: initialHasMore, nextCur
         </ol>
         
         {/* もっと読むボタン */}
+        {loadError && (
+          <p className={styles.loadError}>{loadError}</p>
+        )}
         {hasMore && (
           <div className={styles.loadMore}>
-            <button 
+            <button
               onClick={loadMoreArticles}
               disabled={loading}
               className={styles.loadMoreButton}

--- a/src/styles/articles/index.module.css
+++ b/src/styles/articles/index.module.css
@@ -83,3 +83,10 @@
   opacity: 0.6;
   cursor: not-allowed;
 }
+
+.loadError {
+  color: var(--error-color, #e53e3e);
+  text-align: center;
+  margin: 8px 0;
+  font-size: 14px;
+}


### PR DESCRIPTION
## Summary
- `Notion.tsx`: `console.log` を `console.error` に変更し、エラーコンテキストを追加。`getBlocks`/`appendChildren`/`getOpeningSentence` に try/catch を追加
- `getOgpData.tsx`: 空URLの早期リターン・タイムアウト(10秒)・エラーログの改善
- `articles/index.tsx`: `response.ok` チェックを追加し、失敗時にユーザーへエラーメッセージを表示

## Test plan
- [ ] 記事一覧ページが正常に表示されること
- [ ] 「もっと読む」ボタンが動作すること
- [ ] ネットワーク切断時にエラーメッセージが表示されること

Closes #125

🤖 Generated with [Claude Code](https://claude.com/claude-code)