### PR TITLE
リファクタリング: filterAndSortPagesとformatArticleを共通化してコード重複を解消

### DIFF
--- a/src/components/Notion.tsx
+++ b/src/components/Notion.tsx
@@ -199,6 +199,27 @@ export const getBlocks = async (blockId: string) => {
   return blocks
 }
 
+/// 公開済み・タイトルありの記事のみに絞り込み、新しい順にソートする
+export const filterAndSortPages = (
+  results: QueryDatabaseResponse['results']
+): NotionPage[] => {
+  return (results as NotionPage[])
+    .filter((page) => isPublishDate(page) && getPageTitle(page) !== '')
+    .sort((page, page2) => getPageDate(page2).getTime() - getPageDate(page).getTime())
+}
+
+/// 記事データをUI用の形式に整形する
+export const formatArticle = (page: NotionPage, openingSentence: string) => ({
+  id: page.id,
+  title: getPageTitle(page),
+  date: getPageDate(page).toLocaleDateString('ja-JP', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }),
+  openingSentence,
+})
+
 /// ブロックに子ブロックがあれば付与する（リストブロック・トグルブロック）
 const appendChildren = async (block: ExtendNotionBlock): Promise<ExtendNotionBlock> => {
   if (block.has_children) {

--- a/src/components/Notion.tsx
+++ b/src/components/Notion.tsx
@@ -203,8 +203,10 @@ export const getBlocks = async (blockId: string) => {
 export const filterAndSortPages = (
   results: QueryDatabaseResponse['results']
 ): NotionPage[] => {
-  return (results as NotionPage[])
-    .filter((page) => isPublishDate(page) && getPageTitle(page) !== '')
+  return results
+    .filter((page): page is NotionPage =>
+      'properties' in page && isPublishDate(page as NotionPage) && getPageTitle(page as NotionPage) !== ''
+    )
     .sort((page, page2) => getPageDate(page2).getTime() - getPageDate(page).getTime())
 }
 

--- a/src/pages/api/articles/more.ts
+++ b/src/pages/api/articles/more.ts
@@ -1,11 +1,9 @@
 import type { NextApiRequest, NextApiResponse } from 'next'
 import {
   getDatabaseWithPagination,
-  getPageTitle,
-  getPageDate,
   getOpeningSentence,
-  isPublishDate,
-  type NotionPage,
+  filterAndSortPages,
+  formatArticle,
 } from '../../../components/Notion'
 
 const databaseId = process.env.NOTION_DATABASE_ID || ''
@@ -47,30 +45,12 @@ export default async function handler(
       pageSize
     )
 
-    // フィルタリングとソート
-    const filteredDatabase = response.results
-      .filter(
-        (page) => isPublishDate(page as NotionPage) && getPageTitle(page as NotionPage) !== ''
-      )
-      .sort(
-        (page, page2) =>
-          getPageDate(page2 as NotionPage).getTime() - getPageDate(page as NotionPage).getTime()
-      )
+    const filteredDatabase = filterAndSortPages(response.results)
 
-    // 並行して冒頭文を取得
     const articlesWithOpeningSentences = await Promise.all(
       filteredDatabase.map(async (page) => {
         const openingSentence = await getOpeningSentence(page.id)
-        return {
-          id: page.id,
-          title: getPageTitle(page as NotionPage),
-          date: getPageDate(page as NotionPage).toLocaleDateString('ja-JP', {
-            year: 'numeric',
-            month: '2-digit',
-            day: '2-digit',
-          }),
-          openingSentence,
-        }
+        return formatArticle(page, openingSentence)
       })
     )
 

--- a/src/pages/articles/index.tsx
+++ b/src/pages/articles/index.tsx
@@ -5,7 +5,6 @@ import {
   getOpeningSentence,
   filterAndSortPages,
   formatArticle,
-  type PaginatedDatabaseResponse
 } from '../../components/Notion'
 import styles from '../../styles/articles/index.module.css'
 import Footer from '../../components/Footer'

--- a/src/pages/articles/index.tsx
+++ b/src/pages/articles/index.tsx
@@ -2,11 +2,9 @@ import Header from '../../components/Header'
 import {
   getDatabaseWithPagination,
   sanitizeForUrl,
-  getPageTitle,
-  getPageDate,
   getOpeningSentence,
-  isPublishDate,
-  type NotionPage,
+  filterAndSortPages,
+  formatArticle,
   type PaginatedDatabaseResponse
 } from '../../components/Notion'
 import styles from '../../styles/articles/index.module.css'
@@ -36,31 +34,15 @@ export const getStaticProps = async (context: GetStaticPropsContext) => {
   // ページング対応で記事を取得
   const response = await getDatabaseWithPagination(databaseId, undefined, pageSize)
   
-  // フィルタリングとソート
-  const filteredDatabase = response.results
-    .filter(
-      (page) => isPublishDate(page as NotionPage) && getPageTitle(page as NotionPage) !== ''
-    )
-    .sort(
-      (page, page2) =>
-        getPageDate(page2 as NotionPage).getTime() - getPageDate(page as NotionPage).getTime()
-    )
+  const filteredDatabase = filterAndSortPages(response.results)
 
   const openingSentences = await Promise.all(
     filteredDatabase.map((page) => getOpeningSentence(page.id))
   )
 
-  // 初期記事データを整形
-  const initialArticles = filteredDatabase.map((page, index) => ({
-    id: page.id,
-    title: getPageTitle(page as NotionPage),
-    date: getPageDate(page as NotionPage).toLocaleDateString('ja-JP', {
-      year: 'numeric',
-      month: '2-digit',
-      day: '2-digit',
-    }),
-    openingSentence: openingSentences[index],
-  }))
+  const initialArticles = filteredDatabase.map((page, index) =>
+    formatArticle(page, openingSentences[index])
+  )
 
   return {
     props: {


### PR DESCRIPTION
## Summary
- `filterAndSortPages()` と `formatArticle()` を `Notion.tsx` に共通ヘルパーとして追加
- `index.tsx` と `more.ts` の重複していたフィルタリング・ソート・日付フォーマットロジックを共通関数に統一
- `as NotionPage` のキャストを共通関数内に集約し、呼び出し側をシンプルに

## Test plan
- [ ] `tsc` で型エラーがないことを確認済み
- [ ] 記事一覧が正しく表示されることを確認
- [ ] 「もっと読む」でのページネーションが正しく動作することを確認

Closes #126

🤖 Generated with [Claude Code](https://claude.com/claude-code)