### PR TITLE
feat: OGP取得にキャッシュとレート制限を追加

### DIFF
--- a/src/components/utils/getOgpData.tsx
+++ b/src/components/utils/getOgpData.tsx
@@ -1,16 +1,28 @@
 import openGraphScraper from 'open-graph-scraper'
 import { type OgObject } from 'open-graph-scraper/dist/lib/types.d'
 
+const cache = new Map<string, OgObject>()
+let lastRequestTime = 0
+const RATE_LIMIT_DELAY = 500
+
 const getOgpData = async (url: string): Promise<OgObject> => {
-  const options = { url }
+  if (cache.has(url)) return cache.get(url)!
+
+  const now = Date.now()
+  const elapsed = now - lastRequestTime
+  if (elapsed < RATE_LIMIT_DELAY) {
+    await new Promise<void>((resolve) => setTimeout(resolve, RATE_LIMIT_DELAY - elapsed))
+  }
+  lastRequestTime = Date.now()
 
   try {
-    const { result } = await openGraphScraper(options)
+    const { result } = await openGraphScraper({ url })
 
     if (!result.success) {
       throw new Error('Failed to fetch OGP data')
     }
 
+    cache.set(url, result)
     return result
   } catch (error) {
     console.error('Error fetching OGP data:', error)


### PR DESCRIPTION
closes #130

## Summary
- URLをキーとするメモリキャッシュを追加し、同一URLへの重複フェッチを防止
- リクエスト間に500msのレート制限を追加し、外部サービスのレート制限を回避

## Test plan
- [ ] `npm run build` でビルドエラーがないことを確認
- [ ] OGPリンクカードが正常に表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)