### PR TITLE
パフォーマンス: getOpeningSentenceにキャッシュを追加してNotionのAPI呼び出し回数を削減

### DIFF
--- a/src/components/Notion.tsx
+++ b/src/components/Notion.tsx
@@ -121,7 +121,13 @@ export const getPage = async (pageId: string) => {
 }
 
 /// 冒頭140字を返す。存在しなかったらnullを返す
+const openingSentenceCache = new Map<string, string>()
+
 export const getOpeningSentence = async (blockId: string) => {
+  if (openingSentenceCache.has(blockId)) {
+    return openingSentenceCache.get(blockId)!
+  }
+
   let openingSentence = ''
   let cursor: undefined | string = undefined
 
@@ -147,7 +153,9 @@ export const getOpeningSentence = async (blockId: string) => {
     }
     cursor = next_cursor
   }
-  return openingSentence.substring(0, 140)
+  const result = openingSentence.substring(0, 140)
+  openingSentenceCache.set(blockId, result)
+  return result
 }
 
 /// 指定されたページ（ここではブロックID = ページID）のブロックをすべて返す

--- a/src/components/Notion.tsx
+++ b/src/components/Notion.tsx
@@ -121,6 +121,8 @@ export const getPage = async (pageId: string) => {
 }
 
 /// 冒頭140字を返す。存在しなかったらnullを返す
+// モジュールレベルのキャッシュ。同一プロセス内での重複API呼び出しを防ぐ。
+// Notionの内容を更新した場合はサーバーの再起動が必要。
 const openingSentenceCache = new Map<string, string>()
 
 export const getOpeningSentence = async (blockId: string) => {


### PR DESCRIPTION
## Summary
- `getOpeningSentence` にモジュールレベルの `Map` キャッシュを追加
- 同一ビルド内で同じページIDへの重複API呼び出しを防止
- Notion SDKはNext.jsのfetchキャッシュが使えないため、モジュールキャッシュで対応

## 背景
記事一覧表示時に記事N件分の `getOpeningSentence` が呼ばれており、N+1回のAPIコールが発生していた。`Promise.all` で並列化は済んでいるが、同一ビルド内での重複取得が起きうる状況だった。

## Test plan
- [ ] `tsc` で型エラーがないことを確認済み
- [ ] 記事一覧・記事詳細が正しく表示されることを確認

Closes #123

🤖 Generated with [Claude Code](https://claude.com/claude-code)