### PR TITLE
fix: アクセシビリティ改善

### DIFF
--- a/src/components/Career.tsx
+++ b/src/components/Career.tsx
@@ -4,18 +4,20 @@ export default function Career() {
   return (
     <div className={styles.career}>
       <table>
-        <tbody>
+        <thead>
           <tr>
-            <th>
+            <th scope="col">
               Start<br />
               (year)
             </th>
-            <th>
+            <th scope="col">
               End<br />
               (year)
             </th>
-            <th>Role</th>
+            <th scope="col">Role</th>
           </tr>
+        </thead>
+        <tbody>
           <tr>
             <td>2019</td>
             <td>-</td>

--- a/src/components/Lightbox.tsx
+++ b/src/components/Lightbox.tsx
@@ -21,7 +21,7 @@ export default function Lightbox({ src, alt, onClose }: Props) {
   }, [onClose])
 
   return (
-    <div className={styles.overlay} onClick={onClose}>
+    <div className={styles.overlay} onClick={onClose} role="dialog" aria-modal="true" aria-label="画像拡大表示">
       <button className={styles.closeButton} onClick={onClose} aria-label="閉じる">
         ×
       </button>

--- a/src/components/Lightbox.tsx
+++ b/src/components/Lightbox.tsx
@@ -21,7 +21,7 @@ export default function Lightbox({ src, alt, onClose }: Props) {
   }, [onClose])
 
   return (
-    <div className={styles.overlay} onClick={onClose} role="dialog" aria-modal="true" aria-label="画像拡大表示">
+    <div className={styles.overlay} onClick={onClose} role="dialog" aria-modal="true" aria-label={alt || '画像拡大表示'}>
       <button className={styles.closeButton} onClick={onClose} aria-label="閉じる">
         ×
       </button>

--- a/src/components/utils/renderNotionBlock.tsx
+++ b/src/components/utils/renderNotionBlock.tsx
@@ -200,6 +200,7 @@ export const renderBlock = (
             <div style={{ position: 'relative', paddingBottom: '56.25%', height: 0, overflow: 'hidden', maxWidth: '100%' }}>
               <iframe
                 src={`https://www.youtube.com/embed/${videoId}`}
+                title="YouTube video"
                 style={{ position: 'absolute', top: 0, left: 0, width: '100%', height: '100%' }}
                 allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
                 allowFullScreen
@@ -229,7 +230,7 @@ export const renderBlock = (
     case 'pdf': {
       const pdfValue = block.pdf
       const url = pdfValue.type === 'external' ? pdfValue.external.url : pdfValue.file.url
-      return <iframe src={url} width="100%" height="600px" />
+      return <iframe src={url} title="PDF document" width="100%" height="600px" />
     }
     case 'table':
       return <TableComponent block={block} />


### PR DESCRIPTION
closes #131

## Summary
- **Career.tsx**: ヘッダー行を `<tbody>` から `<thead>` に移動し、各 `<th>` に `scope="col"` を追加
- **Lightbox.tsx**: オーバーレイ div に `role="dialog"`・`aria-modal="true"`・`aria-label="画像拡大表示"` を追加
- **renderNotionBlock.tsx**: YouTube iframeに `title="YouTube video"`、PDF iframeに `title="PDF document"` を追加

## Test plan
- [ ] `npm run build` でビルドエラーがないことを確認
- [ ] Career テーブルがスクリーンリーダーで正しく読み上げられることを確認
- [ ] Lightbox がダイアログとして認識されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)