### PR TITLE
feat: 型安全性改善（型キャストを型ガードに置き換え）(#127)

### DIFF
--- a/src/components/Notion.tsx
+++ b/src/components/Notion.tsx
@@ -26,6 +26,12 @@ export type PaginatedDatabaseResponse = {
   nextCursor: string | null
 }
 
+export const isNotionPage = (page: unknown): page is NotionPage => {
+  if (typeof page !== 'object' || page === null) return false
+  const p = page as Record<string, unknown>
+  return typeof p['id'] === 'string' && typeof p['properties'] === 'object' && p['properties'] !== null
+}
+
 /// Blog記事のデータベースを取得する
 export const getDatabase = async (databaseId: string) => {
   try {
@@ -56,7 +62,7 @@ export const getDatabaseWithPagination = async (databaseId: string, startCursor?
       ],
     })
     return {
-      results: response.results as NotionPage[],
+      results: response.results.filter(isNotionPage),
       hasMore: response.has_more,
       nextCursor: response.next_cursor,
     }

--- a/src/components/utils/renderNotionBlock.tsx
+++ b/src/components/utils/renderNotionBlock.tsx
@@ -40,6 +40,24 @@ const TEXT_BLOCK_TAGS = {
 
 type TextBlockType = keyof typeof TEXT_BLOCK_TAGS
 
+type ExtendParagraphBlock = Extract<ExtendNotionBlock, { type: 'paragraph' }>
+type ExtendHeading1Block = Extract<ExtendNotionBlock, { type: 'heading_1' }>
+type ExtendHeading2Block = Extract<ExtendNotionBlock, { type: 'heading_2' }>
+type ExtendHeading3Block = Extract<ExtendNotionBlock, { type: 'heading_3' }>
+type TextBlock = ExtendParagraphBlock | ExtendHeading1Block | ExtendHeading2Block | ExtendHeading3Block
+
+const isTextBlock = (block: ExtendNotionBlock): block is TextBlock =>
+  block.type in TEXT_BLOCK_TAGS
+
+const getTextBlockContent = (block: TextBlock): RichText[] => {
+  switch (block.type) {
+    case 'paragraph': return block.paragraph.text as RichText[]
+    case 'heading_1': return block.heading_1.text as RichText[]
+    case 'heading_2': return block.heading_2.text as RichText[]
+    case 'heading_3': return block.heading_3.text as RichText[]
+  }
+}
+
 /// 子ブロックを含めたブロックをHTML要素にレンダリングする
 export const renderBlock = (
   { block, tableOfContents, imageSizeMap, onImageClick }: {
@@ -59,14 +77,13 @@ export const renderBlock = (
 
   const { type, id } = block
 
-  if (type in TEXT_BLOCK_TAGS) {
-    const blockType = type as TextBlockType
-    const Tag = TEXT_BLOCK_TAGS[blockType]
-    const value = (block as unknown as Record<string, { text: RichText[] }>)[blockType]
-    const headingId = blockType.startsWith('heading') ? block.id : undefined
+  if (isTextBlock(block)) {
+    const Tag = TEXT_BLOCK_TAGS[block.type]
+    const richTexts = getTextBlockContent(block)
+    const headingId = block.type.startsWith('heading') ? block.id : undefined
     return (
       <Tag id={headingId}>
-        <TextComponent richTexts={value.text} />
+        <TextComponent richTexts={richTexts} />
       </Tag>
     )
   }

--- a/src/pages/api/articles/more.ts
+++ b/src/pages/api/articles/more.ts
@@ -5,7 +5,6 @@ import {
   getPageDate,
   getOpeningSentence,
   isPublishDate,
-  type NotionPage,
 } from '../../../components/Notion'
 
 const databaseId = process.env.NOTION_DATABASE_ID || ''
@@ -39,22 +38,23 @@ export default async function handler(
 
   try {
     const { cursor } = req.query
+    const cursorString = typeof cursor === 'string' ? cursor : undefined
     const pageSize = 10
-    
+
     const response = await getDatabaseWithPagination(
       databaseId,
-      cursor as string | undefined,
+      cursorString,
       pageSize
     )
 
     // フィルタリングとソート
     const filteredDatabase = response.results
       .filter(
-        (page) => isPublishDate(page as NotionPage) && getPageTitle(page as NotionPage) !== ''
+        (page) => isPublishDate(page) && getPageTitle(page) !== ''
       )
       .sort(
         (page, page2) =>
-          getPageDate(page2 as NotionPage).getTime() - getPageDate(page as NotionPage).getTime()
+          getPageDate(page2).getTime() - getPageDate(page).getTime()
       )
 
     // 並行して冒頭文を取得
@@ -63,8 +63,8 @@ export default async function handler(
         const openingSentence = await getOpeningSentence(page.id)
         return {
           id: page.id,
-          title: getPageTitle(page as NotionPage),
-          date: getPageDate(page as NotionPage).toLocaleDateString('ja-JP', {
+          title: getPageTitle(page),
+          date: getPageDate(page).toLocaleDateString('ja-JP', {
             year: 'numeric',
             month: '2-digit',
             day: '2-digit',

--- a/src/pages/articles/index.tsx
+++ b/src/pages/articles/index.tsx
@@ -6,7 +6,6 @@ import {
   getPageDate,
   getOpeningSentence,
   isPublishDate,
-  type PaginatedDatabaseResponse
 } from '../../components/Notion'
 import styles from '../../styles/articles/index.module.css'
 import Footer from '../../components/Footer'

--- a/src/pages/articles/index.tsx
+++ b/src/pages/articles/index.tsx
@@ -6,7 +6,6 @@ import {
   getPageDate,
   getOpeningSentence,
   isPublishDate,
-  type NotionPage,
   type PaginatedDatabaseResponse
 } from '../../components/Notion'
 import styles from '../../styles/articles/index.module.css'
@@ -39,11 +38,11 @@ export const getStaticProps = async (context: GetStaticPropsContext) => {
   // フィルタリングとソート
   const filteredDatabase = response.results
     .filter(
-      (page) => isPublishDate(page as NotionPage) && getPageTitle(page as NotionPage) !== ''
+      (page) => isPublishDate(page) && getPageTitle(page) !== ''
     )
     .sort(
       (page, page2) =>
-        getPageDate(page2 as NotionPage).getTime() - getPageDate(page as NotionPage).getTime()
+        getPageDate(page2).getTime() - getPageDate(page).getTime()
     )
 
   const openingSentences = await Promise.all(
@@ -53,8 +52,8 @@ export const getStaticProps = async (context: GetStaticPropsContext) => {
   // 初期記事データを整形
   const initialArticles = filteredDatabase.map((page, index) => ({
     id: page.id,
-    title: getPageTitle(page as NotionPage),
-    date: getPageDate(page as NotionPage).toLocaleDateString('ja-JP', {
+    title: getPageTitle(page),
+    date: getPageDate(page).toLocaleDateString('ja-JP', {
       year: 'numeric',
       month: '2-digit',
       day: '2-digit',


### PR DESCRIPTION
## Summary
- `Notion.tsx`: `isNotionPage` 型ガード関数を追加し、`getDatabaseWithPagination` の `as NotionPage[]` キャストを置き換え
- `renderNotionBlock.tsx`: `as unknown as Record<...>` という危険な型キャストを `isTextBlock` 型ガードと `getTextBlockContent` ヘルパー関数に置き換え
- `index.tsx` / `more.ts`: `page as NotionPage` キャストをすべて削除（型付きの結果を使用）

## Test plan
- [ ] `tsc --noEmit` でエラーなし
- [ ] 記事一覧ページが正常に表示されること
- [ ] 個別記事ページが正常に表示されること

Closes #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)