### PR TITLE
ホバーエフェクトを色反転から「影 + 浮き上がり」に変更

### DIFF
--- a/src/styles/articles/index.module.css
+++ b/src/styles/articles/index.module.css
@@ -35,6 +35,8 @@
 .post {
   padding: 8px;
   margin: 0 0 16px 0;
+  border-radius: 8px;
+  transition: box-shadow 0.2s ease, transform 0.2s ease;
 }
 
 .postTitle {
@@ -47,13 +49,12 @@
   margin: 0 0 8px 0;
 }
 
-.post:hover,
-.post:hover a,
-.post:hover .postTitle,
-.post:hover .postDescription {
-  color: var(--surface-text-color);
-  background-color: var(--hover-background-color);
-  border-radius: 8px;
+.post:hover {
+  box-shadow: 0 6px 16px var(--hover-shadow-color);
+  transform: translateY(-2px);
+}
+
+.post:hover a {
   text-decoration: none;
 }
 
@@ -75,8 +76,8 @@
 }
 
 .loadMoreButton:hover {
-  color: var(--surface-text-color);
-  background-color: var(--hover-background-color);
+  box-shadow: 0 4px 12px var(--hover-shadow-color);
+  transform: translateY(-2px);
 }
 
 .loadMoreButton:disabled {

--- a/src/styles/global-color.css
+++ b/src/styles/global-color.css
@@ -17,6 +17,7 @@
   --quote-background-color: whitesmoke;
   /* other color */
   --shadow-color: lightgray;
+  --hover-shadow-color: rgba(0, 0, 0, 0.18);
   --border-color: gainsboro;
 }
 
@@ -39,6 +40,7 @@
   --quote-background-color: gray;
   /* other color */
   --shadow-color: darkgray;
+  --hover-shadow-color: rgba(255, 255, 255, 0.18);
   --border-color: dimgray;
 }
 
@@ -63,6 +65,7 @@
     --quote-background-color: gray;
     /* other color */
     --shadow-color: darkgray;
+    --hover-shadow-color: rgba(255, 255, 255, 0.18);
     --border-color: dimgray;
   }
 }

--- a/src/styles/header.module.css
+++ b/src/styles/header.module.css
@@ -22,15 +22,13 @@
   padding: 8px 16px;
   border-radius: 16px;
   box-shadow: 1px 0 4px 1px var(--shadow-color);
+  transition: box-shadow 0.2s ease, transform 0.2s ease;
 }
 
 .active:hover button,
 .active:focus button {
-  color: var(--sub-text-color);
-  background-color: var(--hover-button-background-color);
-  padding: 8px 16px;
-  border-radius: 16px;
-  box-shadow: 1px 0 4px 1px var(--shadow-color);
+  box-shadow: 0 4px 12px var(--hover-shadow-color);
+  transform: translateY(-2px);
 }
 
 .header .inactive button:hover {
@@ -50,9 +48,10 @@
   box-shadow: 1px 0 4px 1px var(--shadow-color);
   margin: 8px;
   cursor: pointer;
+  transition: box-shadow 0.2s ease, transform 0.2s ease;
 }
 
 .actionButtonContainer:hover button {
-  color: var(--surface-text-color);
-  background-color: var(--hover-background-color);
+  box-shadow: 0 4px 12px var(--hover-shadow-color);
+  transform: translateY(-2px);
 }

--- a/src/styles/home/activities.module.css
+++ b/src/styles/home/activities.module.css
@@ -8,6 +8,7 @@
   border-radius: 8px;
   box-shadow: 1px 0 4px 1px var(--shadow-color);
   max-width: 380px;
+  transition: box-shadow 0.2s ease, transform 0.2s ease;
 }
 
 .activity img {
@@ -30,13 +31,7 @@
 }
 
 .activity:hover {
-  background-color: var(--hover-background-color);
-  box-shadow: 1px 0 4px 1px var(--shadow-color);
+  box-shadow: 0 6px 16px var(--hover-shadow-color);
+  transform: translateY(-2px);
   text-decoration: none;
-}
-
-.activity:hover,
-.activity:hover p,
-.activity:hover .description {
-  color: var(--surface-text-color);
 }

--- a/src/styles/home/other-sites.module.css
+++ b/src/styles/home/other-sites.module.css
@@ -12,9 +12,10 @@
   fill: var(--primary-text-color);
   border: 1px solid var(--border-color);
   border-radius: 8px;
+  transition: box-shadow 0.2s ease, transform 0.2s ease;
 }
 
 .button:hover {
-  fill: var(--surface-text-color);
-  background-color: var(--hover-background-color);
+  box-shadow: 0 4px 12px var(--hover-shadow-color);
+  transform: translateY(-2px);
 }

--- a/src/styles/home/works.module.css
+++ b/src/styles/home/works.module.css
@@ -7,6 +7,7 @@
   border: 1px solid var(--border-color);
   border-radius: 8px;
   box-shadow: 1px 0 4px 1px var(--shadow-color);
+  transition: box-shadow 0.2s ease, transform 0.2s ease;
 }
 
 .content {
@@ -36,12 +37,7 @@
 }
 
 .work:hover {
-  background-color: var(--hover-background-color);
-  box-shadow: 1px 0 4px 1px var(--shadow-color);
-  text-decoration: none;;
-}
-
-.work:hover .content,
-.work:hover .description {
-  color: var(--surface-text-color);
+  box-shadow: 0 6px 16px var(--hover-shadow-color);
+  transform: translateY(-2px);
+  text-decoration: none;
 }


### PR DESCRIPTION
Closes #147

クリッカブル要素のホバー時に発生していた「色反転（背景 dimgray + 文字 white）」をやめ、より控えめな **box-shadow を濃く + わずかに浮かせる（translateY）** 表現へ統一する。モダンなWebサイトに合わせた印象に刷新する。

# before

https://github.com/user-attachments/assets/2ef0e07c-f2d3-4873-a8c3-1c24ac3fb307

# after

https://github.com/user-attachments/assets/3475f7a7-3ced-4e6b-ac28-ff12a3fc2bc3